### PR TITLE
Package updates and supertest tests for express prefab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,13 @@ This document provides a log of changes. It is currently maintained by hand.
 ## (master)
 
 - Added methods to extract dependencies from SystemState and Module (for debugging purposes for example)
+- Added the ability to reference the SystemState from a Module
+- Added a system visualization function
+- Updated all dependencies
 - [prefab][express-module] Fixed middleware option TS definitions requiring both `before` and `after` properties
 - [prefab][express-module] Fixed missing middleware options for `use`
+- [prefab][express-module] Added `supertest` tests
+- [prefab][visualize-express-module] Introduced a prefab to expose system visualization through express-module
 
 ## v0.4
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -22,6 +22,9 @@ export class Module {
 
 	getRequiredDependencies(): Module[];
 	getOptionalDependencies(): Module[];
+
+	setSystemStateReference(system: SystemState): void;
+	getSystemStateReference(): SystemState;
 }
 
 export type ClassOfMembers<T> = { [P in keyof T]: ClassOf<T[P]> | string };
@@ -48,3 +51,4 @@ export class SystemState extends Module {
 export type QuickstrapKnownModules = ModuleClass[] | {[alias: string]: ModuleClass};
 export type QuickstrapResult<K> = { state: K, system: SystemState };
 export function quickstrap<K>(requirements: ClassOfMembers<K>, knownModules: QuickstrapKnownModules): Promise<QuickstrapResult<K>>;
+export function visualize(system: SystemState): string;

--- a/package.json
+++ b/package.json
@@ -39,26 +39,28 @@
   },
   "homepage": "https://github.com/walasek/node-modularity#readme",
   "dependencies": {
-    "debug": "4.1.1"
+    "debug": "4.2.0"
   },
   "devDependencies": {
-    "@types/express": "^4.17.7",
+    "@types/express": "4.17.8",
     "@types/mongoose": "5.7.36",
     "docdash": "1.2.0",
-    "eslint": "7.5.0",
-    "eslint-config-prettier": "6.11.0",
+    "eslint": "7.11.0",
+    "eslint-config-prettier": "6.13.0",
     "eslint-plugin-node": "11.1.0",
     "eslint-plugin-prettier": "3.1.4",
     "eslint-plugin-promise": "4.2.1",
     "eslint-plugin-security": "1.4.0",
+    "express": "4.17.1",
     "faucet": "0.0.1",
     "glob": "7.1.6",
-    "jsdoc": "3.6.5",
-    "nodemon": "2.0.4",
+    "jsdoc": "3.6.6",
+    "nodemon": "2.0.5",
     "nyc": "15.1.0",
-    "prettier": "2.0.5",
-    "sinon": "9.0.2",
-    "typescript": "3.9.7",
+    "prettier": "2.1.2",
+    "sinon": "9.2.0",
+    "supertest": "5.0.0",
+    "typescript": "4.0.3",
     "zora": "4.0.0"
   }
 }

--- a/tests/prefabs/express-module-supertest.test.js
+++ b/tests/prefabs/express-module-supertest.test.js
@@ -1,0 +1,24 @@
+const { quickstrap } = require('../..');
+const { ExpressModuleBase } = require('../../prefabs/express-module');
+const supertest = require('supertest');
+const express = require('express');
+
+class MyWebServer extends ExpressModuleBase {
+	constructor() {
+		super(express);
+	}
+}
+
+module.exports = async test => {
+	await test('Middlewares are properly called', async t => {
+		const {
+			state: { web },
+		} = await quickstrap({ web: MyWebServer }, [MyWebServer]);
+		const app = supertest(web.getApp());
+
+		const { status, text } = await app.get('/');
+
+		t.equal(status, 404);
+		t.ok(text.includes('Error'));
+	});
+};


### PR DESCRIPTION
Introduced supertest and express as dev dependencies to later introduce more updates to the tests of express-module prefab.